### PR TITLE
목표 저장 로직 및 주문 STEP 1 보완

### DIFF
--- a/salad-vue/src/components/OrderHeader.vue
+++ b/salad-vue/src/components/OrderHeader.vue
@@ -4,19 +4,21 @@
     <h2 class="title">STEP.01</h2>
   </div>
   <div class="txtBox">
-    <h1>0kcal</h1>
-    <h4 style="margin-top: 12px;">/ {{ store.perMealCalories }}kcal</h4>
+    <h1>{{ ingredientsStore.totalCalories }}kcal</h1>
+    <h4 style="margin-top: 12px;">/ {{ caloriesStore.perMealCalories }}kcal</h4>
   </div>
 </template>
 
 <script setup>
 import { onMounted } from 'vue';
 import { useCaloriesStore } from '@/stores/caloriesStore';
+import { useIngredientsStore } from '@/stores/ingredientsStore';
 
-const store = useCaloriesStore();
+const caloriesStore = useCaloriesStore();
+const ingredientsStore = useIngredientsStore();
 
 onMounted(() => {
-  store.loadFromLocalStorage();
+  caloriesStore.loadFromLocalStorage();
 });
 </script>
 

--- a/salad-vue/src/stores/caloriesStore.js
+++ b/salad-vue/src/stores/caloriesStore.js
@@ -15,7 +15,7 @@ export const useCaloriesStore = defineStore('calories', {
         fat: null,
     }),
     actions: {
-        calculateCalories() {
+        calculateCalories(basedOnGoal = '유지') {
             let BMR = 0;
 
             if (this.gender === 'male') {
@@ -24,11 +24,11 @@ export const useCaloriesStore = defineStore('calories', {
                 BMR = 655 + (9.6 * this.currentWeight) + (1.7 * this.height) - (4.7 * this.age);
             }
 
-            if (this.goal === '유지') {
+            if (basedOnGoal === '유지') {
                 this.recommendedCalories = Math.round(BMR * 1.375); // 유지
-            } else if (this.goal === '감량') {
+            } else if (basedOnGoal === '감량') {
                 this.recommendedCalories = Math.round((BMR * 1.375) - ((BMR * 1.375) * 0.2)); // 감량
-            } else if (this.goal === '증량') {
+            } else if (basedOnGoal === '증량') {
                 this.recommendedCalories = Math.round((BMR * 1.375) + ((BMR * 1.375) * 0.2)); // 증량
             }
 

--- a/salad-vue/src/stores/ingredientsStore.js
+++ b/salad-vue/src/stores/ingredientsStore.js
@@ -1,0 +1,165 @@
+import { defineStore } from 'pinia';
+import { ref, computed, watch } from 'vue';
+
+export const useIngredientsStore = defineStore('ingredients', () => {
+    const ingredients = ref([
+        {
+            name: '파프리카',
+            image: '@/assets/menu1.png',
+            weight: 60,
+            calories: 42,
+            carbs: 10,
+            protein: 1,
+            fat: 0.2,
+            quantity: ref(0),
+        },
+        {
+            name: '토마토',
+            image: '../assets/menu2.png',
+            weight: 50,
+            calories: 18,
+            carbs: 4,
+            protein: 0.9,
+            fat: 0.2,
+            quantity: ref(0),
+        },
+        {
+            name: '양상추',
+            image: '../assets/menu3.png',
+            weight: 100,
+            calories: 15,
+            carbs: 2.9,
+            protein: 1.4,
+            fat: 0.2,
+            quantity: ref(0),
+        },
+        {
+            name: '오이',
+            image: '../assets/menu4.png',
+            weight: 50,
+            calories: 8,
+            carbs: 1.9,
+            protein: 0.3,
+            fat: 0.1,
+            quantity: ref(0),
+        },
+        {
+            name: '당근',
+            image: '../assets/menu5.png',
+            weight: 60,
+            calories: 25,
+            carbs: 6,
+            protein: 0.6,
+            fat: 0.1,
+            quantity: ref(0),
+        },
+        {
+            name: '적양배추',
+            image: '../assets/menu6.png',
+            weight: 50,
+            calories: 22,
+            carbs: 5,
+            protein: 1,
+            fat: 0.2,
+            quantity: ref(0),
+        },
+        {
+            name: '시금치',
+            image: '../assets/menu7.png',
+            weight: 30,
+            calories: 7,
+            carbs: 1.1,
+            protein: 0.9,
+            fat: 0.1,
+            quantity: ref(0),
+        },
+        {
+            name: '아보카도',
+            image: '../assets/menu8.png',
+            weight: 50,
+            calories: 80,
+            carbs: 4,
+            protein: 1,
+            fat: 7,
+            quantity: ref(0),
+        },
+        {
+            name: '올리브',
+            image: '../assets/menu9.png',
+            weight: 10,
+            calories: 115,
+            carbs: 6,
+            protein: 0.8,
+            fat: 10,
+            quantity: ref(0),
+        },
+        {
+            name: '브로콜리',
+            image: '../assets/menu10.png',
+            weight: 50,
+            calories: 17,
+            carbs: 3.3,
+            protein: 1.2,
+            fat: 0.2,
+            quantity: ref(0),
+        },
+    ]);
+
+    const selectedIngredients = ref([]);
+
+    const totalCalories = computed(() => {
+        return selectedIngredients.value.reduce((sum, ingredient) => {
+            return sum + ingredient.quantity * ingredient.calories;
+        }, 0);
+    });
+
+    const toggleIngredient = (ingredient) => {
+        const index = selectedIngredients.value.findIndex(i => i.name === ingredient.name);
+
+        if (index === -1) {
+            // 이미 선택된 재료가 5개인 경우 더 이상 선택할 수 없도록 함
+            if (selectedIngredients.value.length >= 5) {
+                alert('최대 5개의 재료만 선택할 수 있습니다.');
+                return;
+            }
+            selectedIngredients.value.push(ingredient);
+        } else {
+            selectedIngredients.value.splice(index, 1);
+        }
+
+        saveToLocalStorage();
+    };
+
+    const updateQuantity = (ingredient, quantity) => {
+        const index = selectedIngredients.value.findIndex(i => i.name === ingredient.name);
+        console.log('updateQuantity 함수 실행');
+        if (index !== -1) {
+            selectedIngredients.value[index].quantity = quantity;
+            console.log(`재료: ${ingredient.name}, 수량: ${quantity}`);
+        } else {
+            selectedIngredients.value.push({ ...ingredient, quantity });
+        }
+        saveToLocalStorage();
+    };
+
+    const saveToLocalStorage = () => {
+        localStorage.setItem('totalCalories', totalCalories.value);
+        localStorage.setItem('selectedIngredients', JSON.stringify(selectedIngredients.value.map(ingredient => ({
+            name: ingredient.name,
+            quantity: ingredient.quantity
+        }))));
+    };
+
+    watch(selectedIngredients, () => {
+        saveToLocalStorage();
+    }, { deep: true });
+
+
+    return {
+        ingredients,
+        selectedIngredients,
+        totalCalories,
+        toggleIngredient,
+        updateQuantity,
+    };
+});

--- a/salad-vue/src/views/OrderSelect.vue
+++ b/salad-vue/src/views/OrderSelect.vue
@@ -1,37 +1,38 @@
 <template>
   <div>
-    <div></div>
     <orderHeader />
     <h5 style="text-align: center;">최대 5개 선택가능</h5>
-    <div style="display: grid;
-  grid-template-columns: repeat(auto-fill,minmax(160px, 1fr)); gap: 6px;">
-
-      <button class="menuBox" :class="{ active: isActive }" @click="toggleClass">
+    <div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(160px, 1fr)); gap: 6px;">
+      <div v-for="(ingredient, index) in store.ingredients" :key="index" class="menuBox"
+        :class="{ active: store.selectedIngredients.includes(ingredient) }" @click="store.toggleIngredient(ingredient)">
         <v-bottom-sheet v-model="more">
           <template v-slot:activator="{ props }">
             <div class="text-center" style="flex: 1 1 0;">
-              <div style="display: flex;justify-content: flex-end;">
+              <div style="display: flex; justify-content: flex-end;">
                 <div v-bind="props" style="display: flex;">
-                  <h5>더보기</h5> <v-icon>mdi-arrow-right</v-icon>
+                  <h5>더보기</h5>
+                  <v-icon>mdi-arrow-right</v-icon>
                 </div>
               </div>
-              <img src="../assets/menu1.png" alt="menu" style="width: 60px; height: 60px;">
-              <h4>파프리카</h4>
-              <h5>42kcal</h5>
+              <img :src="ingredient.image" alt="menu" style="width: 60px; height: 60px;" />
+              <h4>{{ ingredient.name }}</h4>
+              <h5>{{ ingredient.calories }}kcal</h5>
             </div>
           </template>
           <div class="modal">
             <div class="btn" @click="more = !more">
-              <img src="../assets/menu1.png" alt="menu">
-              <h1>파프리카</h1>
-              <h4>60g / 124kcal</h4>
-              <VNumberInput :reverse="false" controlVariant="split" label="" :hideInput="false" inset />
+              <img :src="ingredient.image" alt="menu" />
+              <h1>{{ ingredient.name }}</h1>
+              <h4>{{ ingredient.weight }} / {{ ingredient.calories }}kcal</h4>
+              <VNumberInput v-model="ingredient.quantity" :min="0" controlVariant="split" label="" :hideInput="false"
+                inset @change="(value) => store.updateQuantity(ingredient, value)" />
               <h3 style="color: #eee;">선택완료</h3>
             </div>
           </div>
         </v-bottom-sheet>
-        <VNumberInput :reverse="false" controlVariant="split" label="" :hideInput="false" inset />
-      </button>
+        <VNumberInput v-model="ingredient.quantity" :min="0" controlVariant="split" label="" :hideInput="false" inset
+          @change="(value) => store.updateQuantity(ingredient, value)" />
+      </div>
     </div>
     <orderFooter />
   </div>
@@ -42,10 +43,12 @@ import orderHeader from '@/components/OrderHeader.vue';
 import orderFooter from '@/components/OrderFooter.vue';
 import { VNumberInput } from 'vuetify/labs/VNumberInput';
 import { ref } from 'vue';
+import { useIngredientsStore } from '@/stores/ingredientsStore';
 
+const store = useIngredientsStore();
 const more = ref(false);
-
 const isActive = ref(false);
+
 function toggleClass() {
   isActive.value = !isActive.value;
 }

--- a/salad-vue/src/views/TargetCaloriesInput.vue
+++ b/salad-vue/src/views/TargetCaloriesInput.vue
@@ -42,6 +42,7 @@
             <h4>
               목표를 선택하세요
             </h4>
+            <p>회원님의 1일 권장 칼로리는 {{ store.recommendedCalories }} kcal 입니다. 목표 선택에 따라 칼로리를 조절해 드려요.</p>
             <div class="selectBox">
               <div class="inputBox select modalselect">
                 <input type="radio" name="target" id="decrement" value="감량" @change="selectTarget('감량')"
@@ -69,15 +70,15 @@
           <template v-slot:activator="{ props }">
             <div class="text-center" style="flex: 1 1 0;">
               <v-btn v-bind="props" class="inputBox">{{ store.mealCount ? `${store.mealCount}끼` : '식사량을 선택하세요'
-              }}</v-btn>
+                }}</v-btn>
             </div>
           </template>
           <div class="modal">
             <h4>
-              목표를 선택하세요
+              식사량을 선택하세요
             </h4>
+            <p>회원님의 1일 권장 칼로리는 {{ store.recommendedCalories }} kcal 입니다. 하루에 몇 끼를 드시는지에 따라 샐러드로 드실 한 끼 칼로리를 나누어 드릴게요.</p>
             <div class="selectBox">
-
               <div style="display: flex; flex: 1 1 0;" class="inputBox select modalselect">
                 <input type="radio" name="amount" id="one" value="1" @change="selectAmount('1')"
                   :checked="tempAmount === '1'">
@@ -101,7 +102,7 @@
         </v-bottom-sheet>
       </div>
     </form>
-
+    <div>목표에 따라 계산된 한 끼 권장 칼로리는 {{ store.perMealCalories }}kcal 입니다.</div>
     <div>
       <RouterLink to="/targetCalories" class="btn" @click.native="calculateAndSaveCalories">
         <h3 style="color: #eee;">저장하기</h3>
@@ -127,8 +128,8 @@ const selectTarget = (value) => {
 
 const confirmTarget = () => {
   store.goal = tempGoal.value;  // 임시 값을 최종 값으로 반영
+  store.calculateCalories(store.goal);  // 목표에 따른 칼로리 계산
   target.value = false;  // 모달 닫기
-  store.saveUserData();  // 목표값 저장
 };
 
 const closeTargetModal = () => {
@@ -142,8 +143,8 @@ const selectAmount = (value) => {
 
 const confirmAmount = () => {
   store.mealCount = parseInt(tempAmount.value);  // 임시 값을 최종 값으로 반영
+  store.calculateCalories(store.goal);  // 끼니 수에 따른 칼로리 계산
   amount.value = false;  // 모달 닫기
-  store.saveUserData();  // 식사량 저장
 };
 
 const closeAmountModal = () => {
@@ -151,15 +152,13 @@ const closeAmountModal = () => {
   amount.value = false;
 };
 
-const calculateAndSaveCalories = () => {
-  store.calculateCalories();
-  store.saveUserData();  // 데이터 저장
-};
-
 // 사용자 입력 데이터 반영
-watch(() => store.age, (newValue) => localStorage.setItem('age', newValue));
-watch(() => store.height, (newValue) => localStorage.setItem('height', newValue));
-watch(() => store.currentWeight, (newValue) => localStorage.setItem('currentWeight', newValue));
+watch(
+  () => [store.gender, store.age, store.height, store.currentWeight],
+  () => {
+    store.calculateCalories(); // 성별, 나이, 키, 체중 입력 시 유지 기준으로 권장 칼로리 계산
+  }
+);
 
 onMounted(() => {
   store.loadFromLocalStorage();


### PR DESCRIPTION
## 목표 저장 로직

- 사용자가 성별, 나이, 키, 체중을 입력한 시점에 'recommendedCalories'가 계산되고, 목표와 끼니 수를 선택하는 모달에서 안내 문구를 띄워주는 기능을 추가했습니다. (ex: 선정님의 1일 권장 칼로리는 1200kcal입니다. 목표 선택에 따라 칼로리를 조정해 드려요.)


## 주문 로직

- STEP 1에 들어갈 채소들을 임의로 10개 선정하여, 배열을 만들었습니다. (src/stores/ingredientsStore.js)
- 배열 요소들로 반복문을 돌려 OrderSelect.vue에 재료 선택 카드가 표시됩니다.
- 최대 5개까지 선택 가능하다는 문구에 맞게 재료는 최대 5개까지 선택 가능하며, 5개 초과 선택시 얼랏이 보입니다.
- 선택한 재료들의 개수를 늘릴 때마다 OrderHeader.vue에 칼로리가 계산되어 보여집니다.